### PR TITLE
Updated config key to prevent clashing with Node

### DIFF
--- a/sonoff.html
+++ b/sonoff.html
@@ -5,7 +5,7 @@ RED.nodes.registerType('Sonoff device', {
     defaults: {
         mode:{ value: '0'},
         broker: { type: 'mqtt-broker', required: true },
-        id: { value: 'sonoff', required: true },
+        device: { value: 'sonoff', required: true },
         name: { value: ''},
         onValue: { value: 'ON' },
         offValue: { value: 'OFF' },
@@ -17,7 +17,7 @@ RED.nodes.registerType('Sonoff device', {
     inputs: 1,
     outputs: 1,
     label: function() {
-        return this.name || this.id;
+        return this.name || this.device;
     }
 });
 </script>
@@ -31,8 +31,8 @@ RED.nodes.registerType('Sonoff device', {
         </select>
     </div>
     <div class="form-row">
-        <label for="node-input-id"><i class="icon-tag"></i> Id</label>
-        <input type="text" id="node-input-id" placeholder="Sonoff id (Default: sonoff)">
+        <label for="node-input-device"><i class="icon-tag"></i> Id</label>
+        <input type="text" id="node-input-device" placeholder="Sonoff id (Default: sonoff)">
     </div>
 
     <div class="form-row">

--- a/sonoff.js
+++ b/sonoff.js
@@ -11,22 +11,22 @@ module.exports = function (RED) {
         const brokerConnection = RED.nodes.getNode(config.broker);
 
         // Topics
-        var topicTeleLWT = `${config.telePrefix}/${config.id}/LWT`;
+        var topicTeleLWT = `${config.telePrefix}/${config.device}/LWT`;
 
-        var topicCmdPower = `${config.cmdPrefix}/${config.id}/power`;
-        var topicCmdStatus = `${config.cmdPrefix}/${config.id}/status`;
+        var topicCmdPower = `${config.cmdPrefix}/${config.device}/power`;
+        var topicCmdStatus = `${config.cmdPrefix}/${config.device}/status`;
 
-        var topicStatsPower = `${config.statPrefix}/${config.id}/POWER`;
-        var topicStatsStatus = `${config.statPrefix}/${config.id}/STATUS`;
+        var topicStatsPower = `${config.statPrefix}/${config.device}/POWER`;
+        var topicStatsStatus = `${config.statPrefix}/${config.device}/STATUS`;
 
         if(config.mode == 1){ //Custom (%topic%/%prefix%/)
-            topicTeleLWT = `${config.id}/${config.telePrefix}/LWT`;
+            topicTeleLWT = `${config.device}/${config.telePrefix}/LWT`;
 
-            topicCmdPower = `${config.id}/${config.cmdPrefix}/power`;
-            topicCmdStatus = `${config.id}/${config.cmdPrefix}/status`;
+            topicCmdPower = `${config.device}/${config.cmdPrefix}/power`;
+            topicCmdStatus = `${config.device}/${config.cmdPrefix}/status`;
 
-            topicStatsPower = `${config.id}/${config.statPrefix}/POWER`;
-            topicStatsStatus = `${config.id}/${config.statPrefix}/STATUS`;
+            topicStatsPower = `${config.device}/${config.statPrefix}/POWER`;
+            topicStatsStatus = `${config.device}/${config.statPrefix}/STATUS`;
         }
 
         if (brokerConnection) {


### PR DESCRIPTION
Node was assigning the ID of the node to the same id as entered for the
device itself. This meant all sorts of internal things were being broken
when Node tried to save any changes to the config relating to this
device.

Hopefully this change cleans up the problem.