### PR TITLE
Added support for sending the "toggle" command.

### DIFF
--- a/sonoff.html
+++ b/sonoff.html
@@ -9,6 +9,7 @@ RED.nodes.registerType('Sonoff device', {
         name: { value: ''},
         onValue: { value: 'ON' },
         offValue: { value: 'OFF' },
+        toggleValue: { value: 'toggle' },
         cmdPrefix: { value: 'cmnd' },
         statPrefix: { value: 'stat' },
         telePrefix: { value: 'tele' }
@@ -53,6 +54,11 @@ RED.nodes.registerType('Sonoff device', {
     <div class="form-row">
         <label for="node-input-offValue"><i class="fa fa-toggle-off"></i> Off</label>
         <input type="text" id="node-input-offValue" placeholder="offValue (Default: OFF)">
+    </div>
+
+    <div class="form-row">
+        <label for="node-input-toggleValue"><i class="fa fa-toggle-on"></i> Toggle</label>
+        <input type="text" id="node-input-toggleValue" placeholder="toggleValue (Default: toggle)">
     </div>
 
     <div class="form-row">

--- a/sonoff.js
+++ b/sonoff.js
@@ -88,9 +88,15 @@ module.exports = function (RED) {
                     this.send({payload: true});
                 }
 
-                if (payload === false || payload === config.offValue) {
+                else if (payload === false || payload === config.offValue) {
                     brokerConnection.client.publish(topicCmdPower, config.offValue, {qos: 0, retain: false});
                     this.send({payload: false});
+                }
+
+                else if (payload === config.toggleValue) {
+                    this.status({fill: 'green',shape: 'dot',text: 'Toggle sent'});
+                    brokerConnection.client.publish(topicCmdPower, config.toggleValue, {qos: 0,retain: false});
+                    this.send({ payload: true });
                 }
             });
 


### PR DESCRIPTION
This PR adds support to send the "toggle" command to Tasmota devices. This can be used to simplify flows that use a push button as a trigger to turn a device either on or off (like remotes).